### PR TITLE
Fixed a crash when the ball runs out of the board.

### DIFF
--- a/Board.cpp
+++ b/Board.cpp
@@ -233,6 +233,11 @@ bool Board::step()
 
     default:
         std::cerr << "WARNING: The ball is arrived at (" << ball->x << ", " << ball->y << "), but this cell is given no action." << std::endl;
+        if ((ball->x < 0) || (ball->x >= width)) {
+            continuing = false;
+            delete ball;
+            ball = nullptr;
+        }
     }
 
     return continuing;


### PR DESCRIPTION
To reproduce the crash:
 1) Menu: Board -> Clear Board
 2) Click on Play.
 3) Wait a few moves.
With this fix the simulation stops when the ball is out and the user can continue placing/moving items on the board.